### PR TITLE
mappings are now saved in an object to prevent mapping source repetition

### DIFF
--- a/lib/rosalina.js
+++ b/lib/rosalina.js
@@ -25,7 +25,7 @@ class Rosalina {
     this.app.use(Router(this.app));
 
     this.headers = {};
-    this.mappings = [];
+    this.mappings = {};
     this.config = {
       remoteBase: remote,
       localBase: local
@@ -33,15 +33,19 @@ class Rosalina {
   }
 
   /**
-   * Creates a new Mapping and adds it to the current instance.
+   * Returns a mapping based on the path defined. If a mapping with
+   * the defined path doesn't exists, then a new mapping is created.
    * @see Mapping
-   * @param {string} route - the path where the application will listen to requests.
+   * @param {string} path - the path where the application will listen to requests.
    * @returns The Mapping object instance.
    */
-  from(route) {
-    let mapping = new Mapping();
-    this.mappings.push(mapping)
-    return mapping.from(route);
+  from(path) {
+    if(path in this.mappings) {
+      return this.mappings[path];
+    }
+
+    this.mappings[path] = new Mapping();
+    return this.mappings[path].from(route);
   }
 
   /**
@@ -54,7 +58,7 @@ class Rosalina {
   }
 
   /**
-   * Builds all the request redirection logic from the defined mappings
+   * Builds all the request redirection logic from the defined mappings.
    * @returns The underlying Koa instance.
    */
 
@@ -95,7 +99,6 @@ class Rosalina {
               if(_.isFunction(to)) {
                 return _.toPairs(to(value))[0];
               } else {
-                let mappedHeader = {};
                 return [to, value];
               }
             }).fromPairs()


### PR DESCRIPTION
Mappings are now saved in an object instead of an array, with the local path as the key.
